### PR TITLE
added feature to allow dummy authentication in jk.webapp

### DIFF
--- a/src/jk.webapp/DummyAuthenticator.sling
+++ b/src/jk.webapp/DummyAuthenticator.sling
@@ -1,0 +1,110 @@
+
+/*
+ * This file is part of Jkop
+ * Copyright (c) 2016-2021 J42 Pte Ltd
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+import jk.env
+import jk.json
+import jk.log
+import jk.url
+import jk.worker
+import jk.http.server
+import jk.http.client
+import jk.http.worker
+import jk.http.server.cookie
+
+class is HTTPServerRequestHandler:
+
+func forEnvironment(ctx as LoggingContext) static as this
+{
+	var v = new this()
+	v.ctx = ctx
+	v.initialize()
+	return v
+}
+
+property ctx as LoggingContext
+{
+}
+
+property cookieName as string = "webAppSession"
+{
+}
+
+property sessionTimeoutSeconds as int = 3600
+{
+}
+
+func initialize
+{
+	Log.debug(ctx, "Dummy authentication enabled")
+}
+
+func getCookieFromRequest(req as HTTPServerRequest) private as string
+{
+	var v = req.getCookieValue(cookieName)
+	if v:
+		return v
+	var v0 = req.getCookieValue(cookieName .. ".0")
+	if not v0:
+		return null
+	var sb = new StringBuilder()
+	sb.appendString(v0)
+	var n = 1
+	loop {
+		var vn = req.getCookieValue(cookieName .. "." .. String.forInteger(n))
+		if not vn:
+			break
+		sb.appendString(vn)
+		n++
+	}
+	return sb.toString()
+}
+
+func handleRequest(req as HTTPServerRequest, next as function)
+{
+	req.removeHeader("x-user-info")
+	var cookie = getCookieFromRequest(req)
+	if String.isNotEmpty(cookie) {
+		req.addHeader("x-user-info", generateDummyData())
+	}
+	if String.isEmpty(cookie) {
+		cookie = generateDummyData()
+	}
+	// This will renew the cookie expiration.
+	var cc = HTTPServerCookie.forKeyValue(cookieName, cookie)
+	cc.setMaxAge(sessionTimeoutSeconds)
+	cc.setPath("/")
+	cc.setSecure(true)
+	cc.setHttpOnly(true)
+	cc.setSameSite("lax")
+	req.addResponseCookie(cc)
+	next()
+}
+
+func generateDummyData as string
+{
+	var dummyData = new DynamicMap()
+	dummyData.setString("name", "dummmy")
+	dummyData.setString("email", "dummmy")
+	return JSONEncoder.toCompactString(dummyData)
+}

--- a/src/jk.webapp/DummyAuthenticator.sling
+++ b/src/jk.webapp/DummyAuthenticator.sling
@@ -59,31 +59,10 @@ func initialize
 	Log.debug(ctx, "Dummy authentication enabled")
 }
 
-func getCookieFromRequest(req as HTTPServerRequest) private as string
-{
-	var v = req.getCookieValue(cookieName)
-	if v:
-		return v
-	var v0 = req.getCookieValue(cookieName .. ".0")
-	if not v0:
-		return null
-	var sb = new StringBuilder()
-	sb.appendString(v0)
-	var n = 1
-	loop {
-		var vn = req.getCookieValue(cookieName .. "." .. String.forInteger(n))
-		if not vn:
-			break
-		sb.appendString(vn)
-		n++
-	}
-	return sb.toString()
-}
-
 func handleRequest(req as HTTPServerRequest, next as function)
 {
 	req.removeHeader("x-user-info")
-	var cookie = getCookieFromRequest(req)
+	var cookie = req.getCookieValue(cookieName)
 	if String.isNotEmpty(cookie) {
 		req.addHeader("x-user-info", generateDummyData())
 	}
@@ -104,6 +83,7 @@ func handleRequest(req as HTTPServerRequest, next as function)
 func generateDummyData as string
 {
 	var dummyData = new DynamicMap()
+	dummyData.setString("oid", "dummy")
 	dummyData.setString("name", "dummmy")
 	dummyData.setString("email", "dummmy")
 	return JSONEncoder.toCompactString(dummyData)

--- a/src/jk.webapp/DummyAuthenticator.sling
+++ b/src/jk.webapp/DummyAuthenticator.sling
@@ -24,6 +24,7 @@
 
 import jk.env
 import jk.json
+import jk.generator
 import jk.log
 import jk.url
 import jk.worker
@@ -64,7 +65,13 @@ func handleRequest(req as HTTPServerRequest, next as function)
 	req.removeHeader("x-user-info")
 	var cookie = req.getCookieValue(cookieName)
 	if String.isNotEmpty(cookie) {
-		req.addHeader("x-user-info", generateDummyData())
+		var cookieData = JSONParser.parseString(cookie) as DynamicMap
+		if cookieData {
+			req.addHeader("x-user-info", cookie)
+		}
+		else {
+			cookie = null
+		}
 	}
 	if String.isEmpty(cookie) {
 		cookie = generateDummyData()
@@ -83,8 +90,8 @@ func handleRequest(req as HTTPServerRequest, next as function)
 func generateDummyData as string
 {
 	var dummyData = new DynamicMap()
-	dummyData.setString("oid", "dummy")
+	dummyData.setString("oid", DataGenerator.generateCodeOrId(64, false, false))
 	dummyData.setString("name", "dummmy")
-	dummyData.setString("email", "dummmy")
+	dummyData.setString("email", "dummmy@gmail.com")
 	return JSONEncoder.toCompactString(dummyData)
 }

--- a/src/jk.webapp/WebAppMain.sling
+++ b/src/jk.webapp/WebAppMain.sling
@@ -41,7 +41,11 @@ property processTemplatesInContentDirectory as bool = true
 
 func pushAuthenticationHandler(ctx as LoggingContext, stack as HTTPServerRequestHandlerStack)
 {
-	if String.equalsIgnoreCase(EnvConfig.getString("WEBAPP_AUTHENTICATOR"), "OIDC") {
+	var allowDummySession = Boolean.asBoolean(EnvironmentVariable.get("DUMMY_SESSION"))
+	if allowDummySession {
+		stack.pushRequestHandler(DummyAuthenticator.forEnvironment(ctx))
+	}
+	else if String.equalsIgnoreCase(EnvConfig.getString("WEBAPP_AUTHENTICATOR"), "OIDC") {
 		var oidc = OidcAuthenticator.forEnvironment(ctx)
 		if oidc:
 			stack.pushRequestHandler(oidc)

--- a/src/jk.webapp/WebAppMain.sling
+++ b/src/jk.webapp/WebAppMain.sling
@@ -41,11 +41,11 @@ property processTemplatesInContentDirectory as bool = true
 
 func pushAuthenticationHandler(ctx as LoggingContext, stack as HTTPServerRequestHandlerStack)
 {
-	var allowDummySession = Boolean.asBoolean(EnvironmentVariable.get("DUMMY_SESSION"))
-	if allowDummySession {
+	var authenticator = EnvConfig.getString("WEBAPP_AUTHENTICATOR")
+	if String.equalsIgnoreCase(authenticator, "DUMMY") {
 		stack.pushRequestHandler(DummyAuthenticator.forEnvironment(ctx))
 	}
-	else if String.equalsIgnoreCase(EnvConfig.getString("WEBAPP_AUTHENTICATOR"), "OIDC") {
+	else if String.equalsIgnoreCase(authenticator, "OIDC") {
 		var oidc = OidcAuthenticator.forEnvironment(ctx)
 		if oidc:
 			stack.pushRequestHandler(oidc)


### PR DESCRIPTION
Feature to allow dummy authentication when using jk.webapp. The simplest way to enable this is to set the environment variable `DUMMY_SESSION=true` when running any sushi app that uses jk.webapp
